### PR TITLE
Increase diamater of Apollo CSM Parachute

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/FASA/RO_FASA_ApolloCSM.cfg
@@ -141,7 +141,7 @@
 		@PARACHUTE
 		{
 			@preDeployedDiameter = 3.17
-			@deployedDiameter = 40.65
+			@deployedDiameter = 60.65
 			@minIsPressure = false
 			%minDeployment = 3200
 			@deploymentAlt = 700


### PR DESCRIPTION
The current diameter of 40.65 meter is too low for the parachute for RO/RP-1. The current size results in a splash down speed of about 8.5m/s (with 3 crew members). This causes the Apollo CSM to "splash down hard" and be destroyed and kills the crew.
I have experimented with the values and found 60.65 meters to be safe value, resulting in a splash down speed of about 6m/s.